### PR TITLE
Fix CLI model selection logic

### DIFF
--- a/src/ogit/main.py
+++ b/src/ogit/main.py
@@ -80,10 +80,19 @@ def main(model=None, list_models=False, set_default_model=False, copy_to_clipboa
 
     models = list_ollama_models()
 
-    if set_default_model or not load_default_model() or load_default_model() not in models:
+    if set_default_model:
         model = prompt_for_model()
-    elif model is None:
-        model = load_default_model()
+    elif model is not None:
+        # use model provided via CLI option
+        if model not in models:
+            print(f"[WARN] Specified model '{model}' not found in available models.")
+        # nothing else to do, CLI-specified model overrides defaults
+    else:
+        default_model = load_default_model()
+        if not default_model or default_model not in models:
+            model = prompt_for_model()
+        else:
+            model = default_model
 
     git_diff = get_git_diff()
     if not git_diff:

--- a/src/ogit/ollama_client.py
+++ b/src/ogit/ollama_client.py
@@ -7,21 +7,21 @@ class OllamaClient:
 
     def send_request(self, payload):
         try:
-            response = requests.post(self.endpoint, json=payload, stream=True)
-            response.raise_for_status()
+            with requests.post(self.endpoint, json=payload, stream=True) as response:
+                response.raise_for_status()
 
-            full_response = ""
-            for line in response.iter_lines(decode_unicode=True):
-                if not line.strip():
-                    continue
-                try:
-                    part = json.loads(line)
-                    full_response += part.get("response", "")
-                except json.JSONDecodeError as e:
-                    print(f"[WARN] Skipped malformed line: {line}")
-                    continue
+                full_response = ""
+                for line in response.iter_lines(decode_unicode=True):
+                    if not line.strip():
+                        continue
+                    try:
+                        part = json.loads(line)
+                        full_response += part.get("response", "")
+                    except json.JSONDecodeError:
+                        print(f"[WARN] Skipped malformed line: {line}")
+                        continue
 
-            return {"response": full_response.strip()}
+                return {"response": full_response.strip()}
 
         except requests.exceptions.RequestException as e:
             print(f"[ERROR] Failed to reach Ollama API: {e}")


### PR DESCRIPTION
## Summary
- respect `--model` argument in absence of default
- warn if user-specified model isn't available
- close HTTP response in `OllamaClient`

## Testing
- `python -m compileall -q src/ogit`

------
https://chatgpt.com/codex/tasks/task_e_684fbe4d13308327a54dff6ad9b3cff9