### PR TITLE
Fix typographic apostrophe in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd ogit
 
 ### 2. Install via `pipx` (recommended)
 
-If you don’t have `pipx` yet:
+If you don't have `pipx` yet:
 
 ```zsh
 brew install pipx


### PR DESCRIPTION
## Summary
- fix ascii apostrophe in README pipx section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbfeacbd88327a52b9f0886ef9ffc